### PR TITLE
请升级com.alibaba:fastjson组件版本以解决10个安全漏洞

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <jjwt.version>0.11.2</jjwt.version>
         <encoding>UTF-8</encoding>
         <orika-core.version>1.5.4</orika-core.version>
-        <fastjson.version>1.2.37</fastjson.version>
+        <fastjson.version>1.2.83</fastjson.version>
         <doctorxiong-club-sub.version>1.0-SNAPSHOT</doctorxiong-club-sub.version>
         <doctorxiong-club-common-module.version>1.0-SNAPSHOT</doctorxiong-club-common-module.version>
         <doctorxiong-club-dubbo-trace-starter.version>1.0-SNAPSHOT</doctorxiong-club-dubbo-trace-starter.version>


### PR DESCRIPTION
将 **com.alibaba:fastjson** 组件从1.2.37 版本升级至 1.2.83版本,
用于修复以下安全漏洞：


序号 | 漏洞编号 | 漏洞标题 | 漏洞级别
-- | -- | -- | --
1 | [MPS-2019-28847](https://www.oscs1024.com/hd/MPS-2019-28847) | Fastjson <= 1.2.60 版本远程代码执行漏洞 | 严重
2 | [MPS-2019-28848](https://www.oscs1024.com/hd/MPS-2019-28848) | Fastjson < 1.2.60 版本拒绝服务漏洞 | 严重
3 | [MPS-2018-27010](https://www.oscs1024.com/hd/MPS-2018-27010) | Fastjson < 1.2.46版本远程代码执行漏洞 | 严重
4 | [MPS-2022-11320](https://www.oscs1024.com/hd/MPS-2022-11320) | Fastjson < 1.2.83 任意代码执行漏洞 | 高危
5 | [MPS-2022-66896](https://www.oscs1024.com/hd/MPS-2022-66896) | Fastjson 1.2.25-1.2.42版本远程代码执行漏洞 | 严重
6 | [MPS-2018-27009](https://www.oscs1024.com/hd/MPS-2018-27009) | Fastjson 1.2.25-1.2.43版本远程代码执行漏洞 | 严重
7 | [MPS-2018-27011](https://www.oscs1024.com/hd/MPS-2018-27011) | Fastjson 1.2.25-1.2.47版本远程代码执行漏洞 | 严重
8 | [MPS-2020-40828](https://www.oscs1024.com/hd/MPS-2020-40828) | Fastjson < 1.2.67远程命令执行漏洞 | 高危
9 | [MPS-2022-66895](https://www.oscs1024.com/hd/MPS-2022-66895) | Fastjson 1.2.25-1.2.41版本远程代码执行漏洞 | 严重
10 | [MPS-2020-39708](https://www.oscs1024.com/hd/MPS-2020-39708) | Fastjson <=1.2.68 远程代码执行漏洞 | 严重
  |   |   |   


<br/>

_注意 ：此 PR 由您（或拥有此仓库权限的其他维护者）授权 [墨菲安全](https://www.murphysec.com) 打开_

了解更多：
- [如何快速修复代码安全问题](https://www.murphysec.com/docs/faqs/security-issues/how-to-quick-fixes.html)
